### PR TITLE
add support for tinyblob

### DIFF
--- a/internal/layers/layer.go
+++ b/internal/layers/layer.go
@@ -384,6 +384,14 @@ func (l *Layer) toEntity(rowType []interface{}, cols []string, colTypes []*sql.C
 			case "BIT":
 				ptrToNullBool := raw.(*HexNullBool)
 				entity.Properties[colName] = ptrToNullBool
+			case "TINYBLOB", "BLOB":
+				ptrToRawBytes := raw.(*sql.RawBytes)
+				if *ptrToRawBytes != nil {
+					// Encode the BLOB data to Base64
+					base64Data := base64.StdEncoding.EncodeToString([]byte(*ptrToRawBytes))
+					val = base64Data
+					entity.Properties[colName] = val
+				}
 			default:
 				l.logger.Infof("Got: %s for %s", ctName, colName)
 			}

--- a/resources/default-config.json
+++ b/resources/default-config.json
@@ -1,0 +1,10 @@
+{
+    "databaseServer" : "",
+    "baseUri" : "",
+    "database" : "",
+    "port" : "1433",
+    "schema" : "",
+    "tableMappings" : [
+
+    ]
+}


### PR DESCRIPTION
datatypes blob and tinyblob needs to be supported. currently the row of data will only be logged and this fix adds support for blobdata. 

Base64 encoding ensures that the binary data is preserved without any loss during serialization and deserialization processes, making it a reliable method for transmitting binary data in textual formats like JSON.