### PR TITLE
add sql time data type from database

### DIFF
--- a/common_layer_integration_test.go
+++ b/common_layer_integration_test.go
@@ -148,6 +148,36 @@ func TestDatasetEndpoint(t *testing.T) {
 		}
 	})
 
+	t.Run("Should set a default value if property is missing", func(t *testing.T) {
+		fileBytes, err := os.ReadFile("./resources/test/testdata_1.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := strings.NewReader(string(fileBytes))
+		http.Post(layerUrl+"/entities", "application/json", payload)
+
+		res, err := http.Get(layerUrl + "/entities")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// entity graph data model
+		entityParser := egdm.NewEntityParser(egdm.NewNamespaceContext()).WithExpandURIs()
+		ec, err := entityParser.LoadEntityCollection(res.Body)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(ec.Entities) != 10 {
+			t.Fatalf("Expected 10 entities, got %d", len(ec.Entities))
+		}
+		if ec.Entities[1].Properties["http://data.sample.org/date_test"] != "2008-11-30T00:00:00Z" {
+			t.Fatalf("Expected date_test to be '2008-11-30T00:00:00Z', got '%s'", ec.Entities[1].Properties["date_test"])
+		}
+	})
+
 	t.Run("Should read changes back from table", func(t *testing.T) {
 		fileBytes, _ := os.ReadFile("./resources/test/testdata_2.json")
 		payload := strings.NewReader(string(fileBytes))

--- a/internal/layer/mysql.go
+++ b/internal/layer/mysql.go
@@ -63,6 +63,7 @@ func (r *RowItem) GetValue(name string) any {
 		} else {
 			return nil
 		}
+
 	case *sql.NullFloat64:
 		if v.Valid {
 			if v.Float64 == float64(int64(v.Float64)) {
@@ -71,6 +72,12 @@ func (r *RowItem) GetValue(name string) any {
 				return v.Float64
 			}
 
+		} else {
+			return nil
+		}
+	case *sql.NullTime:
+		if v.Valid {
+			return v.Time
 		} else {
 			return nil
 		}

--- a/resources/layer/config.json
+++ b/resources/layer/config.json
@@ -54,7 +54,8 @@
                     },
                     {
                         "entity_property": "DateTest",
-                        "property": "date_test"
+                        "property": "date_test",
+                        "default_value": "2008-11-30"
                     },
                     {
                         "entity_property": "DateTimeTest",
@@ -74,6 +75,10 @@
                     {
                         "entity_property": "product_id",
                         "property": "product_id"
+                    },
+                    {
+                        "entity_property": "date_test",
+                        "property": "date_test"
                     }
                 ]
             }

--- a/resources/test/testdata_1.json
+++ b/resources/test/testdata_1.json
@@ -194,7 +194,6 @@
         "ns3:Id": 10,
         "ns3:Reporter": "4",
         "ns3:Timestamp": "2008-11-24T00:00:00Z",
-        "ns3:DateTest": "2008-11-24",
         "ns3:DateTimeTest": "2008-11-25T00:00:00Z",
         "ns3:Version": 0
     }


### PR DESCRIPTION
This pr adds the sql.NullTime type as a possibility to read from database. 

Test checks both default_value in incoming and datetime datatype on outgoing