### PR TITLE
Add handling for duplicate update in same batch & improve delete query

### DIFF
--- a/resources/test/testdata_6.json
+++ b/resources/test/testdata_6.json
@@ -1,0 +1,46 @@
+[
+    {
+        "id": "@context",
+        "namespaces": {
+            "ns0": "http://data.test.io/core/dataset/",
+            "ns1": "http://data.test.io/core/",
+            "ns2": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "ns3": "http://data.test.io/newtestnamespace/product/",
+            "ns4": "http://data.test.io/newtestnamespace/order/"
+        }
+    }
+,{
+    "id": "ns3:1",
+    "recorded": 1616659529376358912,
+    "deleted": false,
+    "refs": {
+        "ns3:Product_Id": "ns4:3096"
+    },
+    "props": {
+        "ns3:Product_Id": 3096,
+        "ns3:ProductPrice": 183,
+        "ns3:Date": "2007-02-16T00:00:00Z",
+        "ns3:Id": 1,
+        "ns3:Reporter": "4",
+        "ns3:Timestamp": "2007-09-09T00:00:00Z",
+        "ns3:Version": 0
+    }
+}
+,{
+    "id": "ns3:1",
+    "recorded": 1616659529376359913,
+    "deleted": false,
+    "refs": {
+        "ns3:Product_Id": "ns4:13003"
+    },
+    "props": {
+        "ns3:Product_Id": 13003,
+        "ns3:ProductPrice": 198,
+        "ns3:Date": "2007-02-17T00:00:00Z",
+        "ns3:Id": 2,
+        "ns3:Reporter": "5",
+        "ns3:Timestamp": "2007-09-10T00:00:00Z",
+        "ns3:Version": 0
+    }
+}
+]


### PR DESCRIPTION
Resolves #30 

* Will now handle duplicate ids in same batch. The entity with the latest recorded timestamp will be commited
* The delete query will now use `delete where id in ()` instead of multiple `or id = foo`